### PR TITLE
"errant" and "Levenshtein" libraries are not loaded during installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,8 @@ setup_dir = os.path.abspath(os.path.dirname(__file__))
 augmentex_path = os.path.join(setup_dir, "wheels/augmentex-1.0.3-py3-none-any.whl")
 
 requirements = [
+    "Levenshtein",
+    "errant",
     "numpy",
     "pandas",
     "tqdm",


### PR DESCRIPTION
Perhaps a stupid commit because you seem to have the logic for loading these libraries, but the "errant" and "Levenshtein" libraries are not loaded during installation and you have to download them manually. Also a small fix, although it could probably be done more elegantly.